### PR TITLE
feat: optimize sync period time cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "eth_light_client_in_ckb-verification",
  "ethers",
  "eyre",
+ "futures",
  "hex",
  "log",
  "openssl",
@@ -2599,9 +2600,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2614,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2624,15 +2625,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2641,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -2672,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2683,15 +2684,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -2705,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -272,8 +272,8 @@ impl Client {
     pub async fn start(&mut self) -> Result<()> {
         if let Err(err) = self.node.write().await.sync().await {
             match err {
-                NodeError::ConsensusSyncError(err) => match err.downcast_ref().unwrap() {
-                    ConsensusError::CheckpointTooOld => {
+                NodeError::ConsensusSyncError(err) => match err.downcast_ref() {
+                    Some(ConsensusError::CheckpointTooOld) => {
                         warn!(
                             "failed to sync consensus node with checkpoint: 0x{}",
                             hex::encode(&self.node.read().await.config.checkpoint),

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+futures = "0.3.26"
 eyre = "0.6.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.85"

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -205,6 +205,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
             futures::future::join_all(tasks).await.into_iter().collect();
         let updates = updates?;
         self.store_finalized_update_batch(&updates)?;
+        info!("headers from {} to {} are synced", start_slot, end_slot);
         Ok(())
     }
 

--- a/consensus/src/constants.rs
+++ b/consensus/src/constants.rs
@@ -2,3 +2,4 @@
 
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration
 pub const MAX_REQUEST_LIGHT_CLIENT_UPDATES: u8 = 128;
+pub const MAX_REQUEST_RPC_UPDATES: u64 = 512;

--- a/consensus/src/constants.rs
+++ b/consensus/src/constants.rs
@@ -3,3 +3,4 @@
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration
 pub const MAX_REQUEST_LIGHT_CLIENT_UPDATES: u8 = 128;
 pub const MAX_REQUEST_RPC_UPDATES: u64 = 512;
+pub const MAX_RPC_RETRY: u8 = 5;

--- a/forcerelay/src/forcerelay.rs
+++ b/forcerelay/src/forcerelay.rs
@@ -56,7 +56,7 @@ impl<R: CkbRpc> ForcerelayClient<R> {
     }
 
     pub async fn assemble_tx(
-        &self,
+        &mut self,
         consensus: &ConsensusClient<impl ConsensusRpc>,
         block: &BeaconBlock,
         tx: &Transaction,
@@ -125,7 +125,7 @@ mod test {
     }
 
     async fn assemble_partial_tx(
-        forcerelay: &ForcerelayClient<MockRpcClient>,
+        forcerelay: &mut ForcerelayClient<MockRpcClient>,
         path: PathBuf,
     ) -> TransactionView {
         let headers: Vec<Header> = load_json_testdata("headers.json").expect("load headers");
@@ -213,7 +213,7 @@ mod test {
     async fn test_assemble_tx() {
         setup_test_logger();
         let context = Arc::new(RefCell::new(Context::default()));
-        let forcerelay = ForcerelayClient::new(
+        let mut forcerelay = ForcerelayClient::new(
             MockRpcClient::new(context.clone()),
             &CONTRACT_TYPEID_ARGS.to_vec(),
             &BINARY_TYPEID_ARGS.to_vec(),
@@ -222,7 +222,7 @@ mod test {
 
         // generate tx
         let path = TempDir::new().unwrap();
-        let tx = assemble_partial_tx(&forcerelay, path.into_path()).await;
+        let tx = assemble_partial_tx(&mut forcerelay, path.into_path()).await;
         let tx = complete_partial_tx(&forcerelay, context.clone(), tx);
 
         // run tx

--- a/forcerelay/testdata/headers.json
+++ b/forcerelay/testdata/headers.json
@@ -1118,5 +1118,19 @@
     "parent_root": "0x638ee0ca8eba1dae6b84eb2bcf03b11c40fb720e0765853f7cb208beb160c745",
     "state_root": "0x70ecd6f1a78c3f515fc1925a5cf9e272b51f73f038566ab18b96564360e84e7c",
     "body_root": "0xb693a3a49811f03a954833547477dc27e9076cd3ccec635007c12bd17ea8d35c"
+  },
+  {
+    "slot": "5763840",
+    "proposer_index": "268747",
+    "parent_root": "0x31d7121c5f4fc4d4c338e2a72a3865f917f638f21d3c6fbbfbd0865890c7de66",
+    "state_root": "0x02078af66325c0e56c969904f7f4f79c7a0135cb6742332918de039687703fd7",
+    "body_root": "0x107c5d3631442f7d280e7e34353e0c621182afc980ffdfaa5e557c59f48c19aa"
+  },
+  {
+    "slot": "5763841",
+    "proposer_index": "118853",
+    "parent_root": "0x4a6e6fa369ff4f48455f2b4242e8305ad41e9eeb0e70ae947adfeda385710523",
+    "state_root": "0x5b9a7766b9119e657f67274e70add77d716b878e031eabdbed9716ca4fcafb68",
+    "body_root": "0x3b7c8fbfc3f0108022d8d22eb8107bd61d0b286addb4aaed660672cf141a7ca9"
   }
 ]


### PR DESCRIPTION
some features I removed:
1. remove `storage.put_finalized_header(slot, update)`.
2. remove `storage.get_fianlized_header(slot)` and replace with the `rpc.get_header(slot)` for every single call.

there're reasons for doing that:
1. fresh headers will always not be stored in the storage, and in case of this, `rpc.get_header` is called instead.
2. there's no need to fetch legacy headers since the whole mmr feature is embedded into the consensus module.
3. `storage.put_finalized_header(slot, update)` is too expensive as an obvious obstacle in the sync process.

@yangby-cryptape  please give me some advice on this.