### PR TITLE
chore: optimize rpc response time and error description

### DIFF
--- a/benches/harness.rs
+++ b/benches/harness.rs
@@ -33,7 +33,7 @@ pub fn construct_mainnet_client(rt: &tokio::runtime::Runtime) -> eyre::Result<cl
 
 pub async fn inner_construct_mainnet_client() -> eyre::Result<client::Client> {
     let benchmark_rpc_url = std::env::var("MAINNET_RPC_URL")?;
-    let mut client = client::ClientBuilder::new()
+    let (mut client, _) = client::ClientBuilder::new()
         .network(networks::Network::MAINNET)
         .consensus_rpc("https://www.lightclientdata.org")
         .execution_rpc(&benchmark_rpc_url)
@@ -47,7 +47,7 @@ pub async fn construct_mainnet_client_with_checkpoint(
     checkpoint: &str,
 ) -> eyre::Result<client::Client> {
     let benchmark_rpc_url = std::env::var("MAINNET_RPC_URL")?;
-    let mut client = client::ClientBuilder::new()
+    let (mut client, _) = client::ClientBuilder::new()
         .network(networks::Network::MAINNET)
         .consensus_rpc("https://www.lightclientdata.org")
         .execution_rpc(&benchmark_rpc_url)
@@ -78,7 +78,7 @@ pub fn construct_runtime() -> tokio::runtime::Runtime {
 pub fn construct_goerli_client(rt: &tokio::runtime::Runtime) -> eyre::Result<client::Client> {
     rt.block_on(async {
         let benchmark_rpc_url = std::env::var("GOERLI_RPC_URL")?;
-        let mut client = client::ClientBuilder::new()
+        let (mut client, _) = client::ClientBuilder::new()
             .network(networks::Network::GOERLI)
             .consensus_rpc("http://testing.prater.beacon-api.nimbus.team")
             .execution_rpc(&benchmark_rpc_url)

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -2,21 +2,20 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use config::networks::Network;
-use consensus::errors::ConsensusError;
 use ethers::prelude::{Address, U256};
 use ethers::types::{Filter, Log, Transaction, TransactionReceipt, H256};
 use eyre::{eyre, Result};
 
 use common::types::BlockTag;
-use config::{CheckpointFallback, Config};
-use consensus::{types::Header, ConsensusClient};
+use config::Config;
+use consensus::types::Header;
 use execution::types::{CallOpts, ExecutionBlock};
-use log::{error, info, warn};
+use log::error;
 use tokio::spawn;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 
-use crate::errors::NodeError;
 use crate::node::Node;
 use crate::rpc::Rpc;
 
@@ -119,7 +118,7 @@ impl ClientBuilder {
         self
     }
 
-    pub fn build(self) -> Result<Client> {
+    pub fn build(self) -> Result<(Client, Sender<()>)> {
         let base_config = if let Some(network) = self.network {
             network.to_base_config()
         } else {
@@ -241,68 +240,59 @@ impl ClientBuilder {
             strict_checkpoint_age,
         };
 
-        Client::new(config)
+        let (sender, receiver) = channel(1);
+        Ok((Client::new(config, receiver)?, sender))
     }
 }
 
 pub struct Client {
     node: Arc<RwLock<Node>>,
+    port: u16,
     rpc: Option<Rpc>,
-    fallback: Option<String>,
-    load_external_fallback: bool,
+    shutdown_receiver: Receiver<()>,
 }
 
 impl Client {
-    fn new(config: Config) -> Result<Self> {
+    fn new(config: Config, shutdown_receiver: Receiver<()>) -> Result<Self> {
         let config = Arc::new(config);
         let node = Node::new(config.clone())?;
-        let node = Arc::new(RwLock::new(node));
-        let rpc = config.rpc_port.map(|port| Rpc::new(node.clone(), port));
+        let port = config.rpc_port.expect("no rpc server");
 
         Ok(Client {
-            node,
-            rpc,
-            fallback: config.fallback.clone(),
-            load_external_fallback: config.load_external_fallback,
+            node: Arc::new(RwLock::new(node)),
+            rpc: None,
+            port,
+            shutdown_receiver,
         })
     }
-}
 
-impl Client {
     pub async fn start(&mut self) -> Result<()> {
-        if let Err(err) = self.node.write().await.sync().await {
-            match err {
-                NodeError::ConsensusSyncError(err) => match err.downcast_ref() {
-                    Some(ConsensusError::CheckpointTooOld) => {
-                        warn!(
-                            "failed to sync consensus node with checkpoint: 0x{}",
-                            hex::encode(&self.node.read().await.config.checkpoint),
-                        );
+        {
+            let mut rpc = Rpc::new(self.node.clone(), self.port);
+            rpc.start(false).await?;
 
-                        let fallback = self.boot_from_fallback().await;
-                        if fallback.is_err() && self.load_external_fallback {
-                            self.boot_from_external_fallbacks().await?
-                        } else if fallback.is_err() {
-                            error!("Invalid checkpoint. Please update your checkpoint too a more recent block. Alternatively, set an explicit checkpoint fallback service url with the `-f` flag or use the configured external fallback services with `-l` (NOT RECOMMENDED). See https://github.com/a16z/helios#additional-options for more information.");
-                            return Err(err);
-                        }
+            let mut node = self.node.write().await;
+            tokio::select! {
+                result = node.sync() => {
+                    if let Err(err) = result {
+                        return Err(err.into());
                     }
-                    _ => return Err(err),
                 },
-                _ => return Err(err.into()),
+                _ = self.shutdown_receiver.recv() => {
+                    return Ok(());
+                }
             }
         }
 
-        if let Some(rpc) = &mut self.rpc {
-            rpc.start().await?;
-        }
+        let mut rpc = Rpc::new(self.node.clone(), self.port);
+        rpc.start(true).await?;
+        self.rpc = Some(rpc);
 
         let node = self.node.clone();
         spawn(async move {
             loop {
-                let res = node.write().await.advance().await;
-                if let Err(err) = res {
-                    warn!("consensus error: {}", err);
+                if let Err(err) = node.write().await.advance().await {
+                    error!("consensus error: {}", err);
                 }
 
                 let next_update = node.read().await.duration_until_next_update();
@@ -310,75 +300,6 @@ impl Client {
             }
         });
 
-        Ok(())
-    }
-
-    async fn boot_from_fallback(&self) -> eyre::Result<()> {
-        if let Some(fallback) = &self.fallback {
-            info!(
-                "attempting to load checkpoint from fallback \"{}\"",
-                fallback
-            );
-
-            let checkpoint = CheckpointFallback::fetch_checkpoint_from_api(fallback)
-                .await
-                .map_err(|_| {
-                    eyre::eyre!("Failed to fetch checkpoint from fallback \"{}\"", fallback)
-                })?;
-
-            info!(
-                "external fallbacks responded with checkpoint 0x{:?}",
-                checkpoint
-            );
-
-            // Try to sync again with the new checkpoint by reconstructing the consensus client
-            // We fail fast here since the node is unrecoverable at this point
-            let config = self.node.read().await.config.clone();
-            let consensus =
-                ConsensusClient::new(&config.consensus_rpc, checkpoint.as_bytes(), config.clone())?;
-            self.node.write().await.consensus = consensus;
-            self.node.write().await.sync().await?;
-
-            Ok(())
-        } else {
-            Err(eyre::eyre!("no explicit fallback specified"))
-        }
-    }
-
-    async fn boot_from_external_fallbacks(&self) -> eyre::Result<()> {
-        info!("attempting to fetch checkpoint from external fallbacks...");
-        // Build the list of external checkpoint fallback services
-        let list = CheckpointFallback::new()
-            .build()
-            .await
-            .map_err(|_| eyre::eyre!("Failed to construct external checkpoint sync fallbacks"))?;
-
-        let checkpoint = if self.node.read().await.config.chain.chain_id == 5 {
-            list.fetch_latest_checkpoint(&Network::GOERLI)
-                .await
-                .map_err(|_| {
-                    eyre::eyre!("Failed to fetch latest goerli checkpoint from external fallbacks")
-                })?
-        } else {
-            list.fetch_latest_checkpoint(&Network::MAINNET)
-                .await
-                .map_err(|_| {
-                    eyre::eyre!("Failed to fetch latest mainnet checkpoint from external fallbacks")
-                })?
-        };
-
-        info!(
-            "external fallbacks responded with checkpoint {:?}",
-            checkpoint
-        );
-
-        // Try to sync again with the new checkpoint by reconstructing the consensus client
-        // We fail fast here since the node is unrecoverable at this point
-        let config = self.node.read().await.config.clone();
-        let consensus =
-            ConsensusClient::new(&config.consensus_rpc, checkpoint.as_bytes(), config.clone())?;
-        self.node.write().await.consensus = consensus;
-        self.node.write().await.sync().await?;
         Ok(())
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -285,6 +285,7 @@ impl Client {
         }
 
         let mut rpc = Rpc::new(self.node.clone(), self.port);
+        println!("end sync");
         rpc.start(true).await?;
         self.rpc = Some(rpc);
 

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -15,9 +15,6 @@ pub enum NodeError {
     #[error("consensus payload error: {0}")]
     ConsensusPayloadError(Report),
 
-    #[error("execution payload error: {0}")]
-    ExecutionPayloadError(Report),
-
     #[error("consensus client creation error: {0}")]
     ConsensusClientCreationError(Report),
 
@@ -36,7 +33,7 @@ pub enum NodeError {
     #[error(transparent)]
     BlockNotFoundError(#[from] BlockNotFoundError),
 
-    #[error("block_number {0} is out of range [{1}, {2}]")]
+    #[error("transaction's block {0} is out of workable range [{1}, {2}]")]
     BlockNumberToSlotError(u64, u64, u64),
 }
 

--- a/client/src/node.rs
+++ b/client/src/node.rs
@@ -484,15 +484,18 @@ impl Node {
                     client.maximal_slot
                 ));
             }
-            let ckb_transaction = self.forcerelay.assemble_tx(
-                &client,
-                &client_celldep,
-                &self.consensus,
-                &block,
-                &eth_transaction,
-                &eth_receipt,
-                &all_receipts,
-            )?;
+            let ckb_transaction = self
+                .forcerelay
+                .assemble_tx(
+                    client,
+                    &client_celldep,
+                    &self.consensus,
+                    &block,
+                    &eth_transaction,
+                    &eth_receipt,
+                    &all_receipts,
+                )
+                .await?;
             return Ok(Some(ckb_transaction.data().into()));
         }
         Ok(None)

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -53,6 +53,13 @@ impl Rpc {
 
         Ok(addr)
     }
+
+    pub async fn stop(self) -> Result<()> {
+        if let Some(handle) = self.handle {
+            handle.stop()?.await?;
+        }
+        Ok(())
+    }
 }
 
 #[rpc(server, namespace = "eth")]

--- a/config/tests/checkpoints.rs
+++ b/config/tests/checkpoints.rs
@@ -31,16 +31,18 @@ async fn test_fetch_latest_checkpoints() {
         .build()
         .await
         .unwrap();
-    let checkpoint = cf
-        .fetch_latest_checkpoint(&networks::Network::GOERLI)
-        .await
-        .unwrap();
-    assert!(checkpoint != H256::zero());
+    let checkpoint = cf.fetch_latest_checkpoint(&networks::Network::GOERLI).await;
+    match checkpoint {
+        Ok(value) => assert!(value != H256::zero()),
+        Err(error) => assert!(error.to_string() == "No checkpoint found"),
+    };
     let checkpoint = cf
         .fetch_latest_checkpoint(&networks::Network::MAINNET)
-        .await
-        .unwrap();
-    assert!(checkpoint != H256::zero());
+        .await;
+    match checkpoint {
+        Ok(value) => assert!(value != H256::zero()),
+        Err(error) => assert!(error.to_string() == "No checkpoint found"),
+    };
 }
 
 #[tokio::test]

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -657,7 +657,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
             .as_secs();
 
         let time_to_next_slot = next_slot_timestamp.saturating_sub(now);
-        let next_update = time_to_next_slot + 4;
+        let next_update = time_to_next_slot + 3;
 
         Duration::seconds(next_update as i64)
     }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -205,7 +205,6 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
             futures::future::join_all(tasks).await.into_iter().collect();
         let updates = updates?;
         self.store_finalized_update_batch(&updates)?;
-        info!("headers from {} to {} are synced", start_slot, end_slot);
         Ok(())
     }
 
@@ -243,7 +242,7 @@ impl<R: ConsensusRpc> ConsensusClient<R> {
         let finalized_header = match finalized_header {
             Ok(Some(header)) => header,
             Ok(None) => {
-                warn!("beacon header {finality_update_slot} is forked or skipped");
+                warn!("forked or skipped beacon header ({finality_update_slot})");
                 Header {
                     slot: finality_update_slot,
                     ..Default::default()

--- a/consensus/src/constants.rs
+++ b/consensus/src/constants.rs
@@ -2,5 +2,5 @@
 
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration
 pub const MAX_REQUEST_LIGHT_CLIENT_UPDATES: u8 = 128;
-pub const MAX_REQUEST_RPC_UPDATES: u64 = 512;
+pub const MAX_REQUEST_RPC_UPDATES: u64 = 32;
 pub const MAX_RPC_RETRY: u8 = 5;

--- a/consensus/tests/sync.rs
+++ b/consensus/tests/sync.rs
@@ -19,7 +19,8 @@ async fn setup(path: PathBuf) -> ConsensusClient<MockRpc> {
     let checkpoint =
         hex::decode("1e591af1e90f2db918b2a132991c7c2ee9a4ab26da496bd6e71e4f0bd65ea870").unwrap();
 
-    ConsensusClient::new("testdata/", &checkpoint, Arc::new(config)).unwrap()
+    let consensus = ConsensusClient::new("testdata/", &checkpoint, Arc::new(config)).unwrap();
+    consensus
 }
 
 #[tokio::test]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let consensus_rpc = "https://www.lightclientdata.org";
     log::info!("Using consensus RPC URL: {}", consensus_rpc);
 
-    let mut client = ClientBuilder::new()
+    let (mut client, _) = ClientBuilder::new()
         .network(Network::MAINNET)
         .consensus_rpc(consensus_rpc)
         .execution_rpc(untrusted_rpc_url)
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
         Network::MAINNET
     );
 
+    // start here will be running for a LONG time period
     client.start().await?;
 
     let head_block_num = client.get_block_number().await?;

--- a/forcerelay/src/forcerelay.rs
+++ b/forcerelay/src/forcerelay.rs
@@ -59,9 +59,9 @@ impl<R: CkbRpc> ForcerelayClient<R> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn assemble_tx(
+    pub async fn assemble_tx(
         &mut self,
-        client: &OnChainClient,
+        client: OnChainClient,
         client_celldep: &CellDep,
         consensus: &ConsensusClient<impl ConsensusRpc>,
         block: &BeaconBlock,
@@ -69,15 +69,17 @@ impl<R: CkbRpc> ForcerelayClient<R> {
         receipt: &TransactionReceipt,
         all_receipts: &[TransactionReceipt],
     ) -> Result<TransactionView> {
-        self.assembler.assemble_tx(
-            client,
-            client_celldep,
-            consensus,
-            block,
-            tx,
-            receipt,
-            all_receipts,
-        )
+        self.assembler
+            .assemble_tx(
+                client,
+                client_celldep,
+                consensus,
+                block,
+                tx,
+                receipt,
+                all_receipts,
+            )
+            .await
     }
 }
 
@@ -161,7 +163,7 @@ mod test {
             .expect("update binary celldep");
         forcerelay
             .assemble_tx(
-                &client,
+                client,
                 &client_celldep,
                 &consensus,
                 &block,
@@ -169,6 +171,7 @@ mod test {
                 &receipt,
                 &all_receipts,
             )
+            .await
             .expect("assemble partial")
     }
 

--- a/forcerelay/tests/lib.rs
+++ b/forcerelay/tests/lib.rs
@@ -271,7 +271,7 @@ fn finish_tx(partial_tx: Transaction) -> Transaction {
 async fn run_verifier() -> Result<()> {
     let checkpoint = "0xe06056afdb9a0a9fd7fbaf89bb0e96eced24de0104bc5b7e3960c115d6990f90";
 
-    let mut client = ClientBuilder::new()
+    let (mut client, _) = ClientBuilder::new()
         .network(networks::Network::MAINNET)
         .consensus_rpc("http://127.0.0.1:8444")
         .execution_rpc("http://127.0.0.1:8444")


### PR DESCRIPTION
Optimize with the following 6 changes:
1. cache block receipts to eliminate the recent request cost of calling `get_block_receipts()` rpc within 512 slots
2. remove 3 times of calling `fetch_live_cells()` rpc
3. report an error to replace returning `None` when calling the `forcerelay_getCkbForcerelayTransaction` method
4. use a peaceful method to handle the insecure exit progress, e.g. ctrl-c pressed or internal panic
5. enable a safe exit while in the progress of chasing the tip
6. enable the `forcerelay_getCkbForcerelayTransaction` rpc response while in the chasing progress, and the response is showing the verifier is in CHASING status